### PR TITLE
Fix "slow" GTK apps

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,4 +12,4 @@ chmod +x ./krunner_appmenu.py
 
 nohup ./krunner_appmenu.py >/dev/null 2>&1 &
 
-kquitapp5 krunner
+kquitapp6 krunner

--- a/krunner_appmenu.py
+++ b/krunner_appmenu.py
@@ -3,6 +3,7 @@
 import logging
 import re
 import threading
+import time
 import unicodedata
 from enum import Enum
 from itertools import filterfalse
@@ -91,7 +92,14 @@ class AppmenuXWindowInfo(object):
             if window.get_wm_class() == ('krunner', 'krunner'):
                 logger.debug("active window is krunner, ignoring")
                 return
-            appmenu = self._get_appmenu_names(window)
+            
+            appmenu = (None, None)
+            for _ in range(5):
+                appmenu = self._get_appmenu_names(window)
+                if all(appmenu):
+                    break
+                time.sleep(0.1)
+            
             logger.debug("active window has appmenu %r", appmenu)
 
         self._active_window_id = winid

--- a/krunner_appmenu.py
+++ b/krunner_appmenu.py
@@ -93,6 +93,10 @@ class AppmenuXWindowInfo(object):
                 logger.debug("active window is krunner, ignoring")
                 return
             
+            """
+            Some applications, particularly GTK, can be slow to publish their D-Bus menu in KDE,
+            so we try to fetch the appmenu properties for up to 0.5 seconds before giving up
+            """
             appmenu = (None, None)
             for _ in range(5):
                 appmenu = self._get_appmenu_names(window)


### PR DESCRIPTION
Some applications, particularly GTK, can be slow to publish their D-Bus menu in KDE, Probably because KDE goes through gdbusmenu. This can cause the KRunner plugin to fail to find the menu on the first try.

This change introduces a retry mechanism in the `_update_active_appmenu` method. When a new window becomes active, the plugin will now try to fetch the appmenu properties for up to 0.5 seconds before giving up. This gives slower applications enough time to start and advertise their menus.

Additionally, the `install.sh` script has been updated to use `kquitapp6` for compatibility with Plasma 6.